### PR TITLE
Fix about chapter footer styling

### DIFF
--- a/src/frontend/src/pages/ChapterAbout/ChapterAbout.style.tsx
+++ b/src/frontend/src/pages/ChapterAbout/ChapterAbout.style.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components/macro'
 
 export const ChapterAboutStyled = styled.div`
-  height: calc(100vh - 130px);
   margin: 74px 20px 0;
 `
 


### PR DESCRIPTION
seems that styling in the new About pages is a bit broken the footer is higher than it should be.
it's reproducible on resolution 1366x768

before:
![Screenshot 2021-10-27 at 07-05-41 Learn to write Tezos Smart Contracts the fun way TezosAcademy](https://user-images.githubusercontent.com/782268/139003385-0042c2fc-9416-4bd3-9f32-a173c995dd42.png)

after:
![Screenshot 2021-10-27 at 07-05-26 Learn to write Tezos Smart Contracts the fun way TezosAcademy](https://user-images.githubusercontent.com/782268/139003387-f1335b27-3cd0-4904-af25-2c6883372f9a.png)